### PR TITLE
Fixes OTFDesignSystem wrong version on Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ target 'OTFTemplateBox' do
   pod 'OTFCareKitUI', '2.0.2-beta.4'
   pod 'OTFToolBoxCore', '1.0.4-beta'
   pod 'OTFUtilities', '1.0.1-beta'
-  pod 'OTFDesignSystem', '1.0.0'
+  pod 'OTFDesignSystem', '1.0.0-beta'
   
   target 'OTFTemplateBoxTests' do
     # Pods for testing


### PR DESCRIPTION
While exploring this repo, I noticed that it was referencing a wrong version of OTFDesignSystem framework, which failed to run `pod install`.